### PR TITLE
chore: bump Ghost to 6.43.1; 6.42.0:0 → 6.43.1:0

### DIFF
--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -14,7 +14,7 @@ export const manifest = setupManifest({
   images: {
     ghost: {
       source: {
-        dockerTag: 'ghost:6.42.0-alpine',
+        dockerTag: 'ghost:6.43.1-alpine',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,13 +1,13 @@
 import { VersionInfo, IMPOSSIBLE } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '6.42.0:0',
+  version: '6.43.1:0',
   releaseNotes: {
-    en_US: 'Bumps Ghost → 6.42.0.',
-    es_ES: 'Actualiza Ghost → 6.42.0.',
-    de_DE: 'Aktualisiert Ghost → 6.42.0.',
-    pl_PL: 'Aktualizuje Ghost → 6.42.0.',
-    fr_FR: 'Met à jour Ghost → 6.42.0.',
+    en_US: 'Bumps Ghost → 6.43.1.',
+    es_ES: 'Actualiza Ghost → 6.43.1.',
+    de_DE: 'Aktualisiert Ghost → 6.43.1.',
+    pl_PL: 'Aktualizuje Ghost → 6.43.1.',
+    fr_FR: 'Met à jour Ghost → 6.43.1.',
   },
   migrations: {
     up: async ({ effects }) => {},


### PR DESCRIPTION
## Summary

Bumps the wrapped Ghost image from `6.42.0-alpine` to `6.43.1-alpine`, taking the package from `6.42.0:0` → `6.43.1:0`.

This is a minor upstream bump (feature + fix release). No package-level breaking changes, no state migration required. MySQL pin (`8.4.9`) and `@start9labs/start-sdk` (`1.5.3`, already latest) are unchanged.

### Upstream changes (6.42.0 → 6.43.1)

**6.43.0**
- ✨ Relative date filters for members and comments
- ✨ Frontend admin toolbar
- 🐛 Fixes: Mastodon social-account field input, future filter date selection, theme editor launch gate, post-analytics first-day traffic, API feature-image captions, production builds using unpinned dependencies

**6.43.1**
- 🐛 Fixed members-only 403 leaking when `llms.txt` is disabled

### Changes
- `startos/manifest/index.ts` — Ghost image tag → `6.43.1-alpine`
- `startos/versions/current.ts` — `version` → `6.43.1:0`, release notes updated in all locales

### Test plan
- `npm run check` (tsc --noEmit) passes
- Full `make` build verification to follow in review