### PR TITLE
chore: bump Ghost to 6.44.0; 6.43.1:0 → 6.44.0:0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -87,9 +87,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
-      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -14,7 +14,7 @@ export const manifest = setupManifest({
   images: {
     ghost: {
       source: {
-        dockerTag: 'ghost:6.43.1-alpine',
+        dockerTag: 'ghost:6.44.0-alpine',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -14,7 +14,7 @@ export const manifest = setupManifest({
   images: {
     ghost: {
       source: {
-        dockerTag: 'ghost:6.44.0-alpine',
+        dockerTag: 'ghost:6.44.1-alpine',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,13 +1,13 @@
 import { VersionInfo, IMPOSSIBLE } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '6.43.1:0',
+  version: '6.44.0:0',
   releaseNotes: {
-    en_US: 'Bumps Ghost → 6.43.1.',
-    es_ES: 'Actualiza Ghost → 6.43.1.',
-    de_DE: 'Aktualisiert Ghost → 6.43.1.',
-    pl_PL: 'Aktualizuje Ghost → 6.43.1.',
-    fr_FR: 'Met à jour Ghost → 6.43.1.',
+    en_US: 'Bumps Ghost → 6.44.0.',
+    es_ES: 'Actualiza Ghost → 6.44.0.',
+    de_DE: 'Aktualisiert Ghost → 6.44.0.',
+    pl_PL: 'Aktualizuje Ghost → 6.44.0.',
+    fr_FR: 'Met à jour Ghost → 6.44.0.',
   },
   migrations: {
     up: async ({ effects }) => {},

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,13 +1,13 @@
 import { VersionInfo, IMPOSSIBLE } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '6.44.0:0',
+  version: '6.44.1:0',
   releaseNotes: {
-    en_US: 'Bumps Ghost → 6.44.0.',
-    es_ES: 'Actualiza Ghost → 6.44.0.',
-    de_DE: 'Aktualisiert Ghost → 6.44.0.',
-    pl_PL: 'Aktualizuje Ghost → 6.44.0.',
-    fr_FR: 'Met à jour Ghost → 6.44.0.',
+    en_US: 'Bumps Ghost → 6.44.1.',
+    es_ES: 'Actualiza Ghost → 6.44.1.',
+    de_DE: 'Aktualisiert Ghost → 6.44.1.',
+    pl_PL: 'Aktualizuje Ghost → 6.44.1.',
+    fr_FR: 'Met à jour Ghost → 6.44.1.',
   },
   migrations: {
     up: async ({ effects }) => {},


### PR DESCRIPTION
## Summary

Bumps Ghost from 6.43.1 → 6.44.0 (minor). StartOS version `6.43.1:0` → `6.44.0:0`.

- `images.ghost.source.dockerTag`: `ghost:6.43.1-alpine` → `ghost:6.44.0-alpine`
- MySQL stays at `8.4.9` (LTS, supported by this Ghost release).
- `@start9labs/start-sdk` already at latest `1.5.3` — no SDK bump.

## Upstream changelog (6.43.1 → 6.44.0)

All changes are internal to the Ghost app — no packaging impact:

- ✨ Added Klipy as a GIF provider alongside Tenor
- 🎨 Updated Source theme → v1.7.0, Casper → v5.12.0
- 🎨 Archived tiers added to tier filter
- 🎨 Analytics CSV exports now include the site name
- 🐛 Fixed bookmark card favicons not loading after first save
- 🐛 Fixed staff invite error for existing users
- 🐛 Fixed design preview showing raw markdown when llms.txt is enabled

Full diff: https://github.com/TryGhost/Ghost/compare/v6.43.1...v6.44.0

## Test plan

- [x] `npm run check` (tsc --noEmit) green