### PR TITLE
chore: bump Ghost to 6.45.0; 6.44.1:0 → 6.45.0:0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -87,9 +87,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
-      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -107,9 +107,9 @@
       }
     },
     "node_modules/anynum": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
-      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
       "funding": [
         {
           "type": "github",
@@ -228,9 +228,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.1.tgz",
+      "integrity": "sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ==",
       "funding": [
         {
           "type": "github",
@@ -259,9 +259,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
-      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
       "funding": [
         {
           "type": "github",
@@ -270,7 +270,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "anynum": "^1.0.0"
+        "anynum": "^1.0.1"
       }
     },
     "node_modules/tr46": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,9 +49,9 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
-      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
       "funding": [
         {
           "type": "github",
@@ -87,9 +87,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.20",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
-      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
+      "version": "22.19.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
+      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -105,6 +105,18 @@
       "bin": {
         "ncc": "dist/ncc/cli.js"
       }
+    },
+    "node_modules/anynum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
+      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/deep-equality-data-structures": {
       "version": "2.0.0",
@@ -231,9 +243,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -247,16 +259,19 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
-      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
+      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.0"
+      }
     },
     "node_modules/tr46": {
       "version": "0.0.3",

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -14,7 +14,7 @@ export const manifest = setupManifest({
   images: {
     ghost: {
       source: {
-        dockerTag: 'ghost:6.45.0-alpine',
+        dockerTag: 'ghost:6.46.0-alpine',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -14,7 +14,7 @@ export const manifest = setupManifest({
   images: {
     ghost: {
       source: {
-        dockerTag: 'ghost:6.44.1-alpine',
+        dockerTag: 'ghost:6.45.0-alpine',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,43 +1,43 @@
 import { VersionInfo, IMPOSSIBLE } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '6.45.0:0',
+  version: '6.46.0:0',
   releaseNotes: {
-    en_US: `Updated Ghost to 6.45.0.
+    en_US: `Updated Ghost to 6.46.0.
 
-- Added IndexNow to notify search engines of content changes.
-- Updated the Source and Casper themes.
-- Numerous bug fixes across comments, members, the editor, and Portal.
+- Fixed disabling structured data for LLMs and AI search engines.
+- Fixed importer silently dropping content by surfacing validation errors.
+- Numerous fixes across members, newsletters, checkout, and the editor.
 
-Full release notes: https://github.com/TryGhost/Ghost/releases/tag/v6.45.0`,
-    es_ES: `Actualiza Ghost a 6.45.0.
+Full release notes: https://github.com/TryGhost/Ghost/releases/tag/v6.46.0`,
+    es_ES: `Actualiza Ghost a 6.46.0.
 
-- Añade IndexNow para notificar a los motores de búsqueda los cambios de contenido.
-- Actualiza los temas Source y Casper.
-- Numerosas correcciones en comentarios, miembros, el editor y Portal.
+- Corrige la desactivación de los datos estructurados para LLM y buscadores con IA.
+- Corrige que el importador descartara contenido en silencio, mostrando errores de validación.
+- Numerosas correcciones en miembros, boletines, el pago y el editor.
 
-Notas de la versión completas: https://github.com/TryGhost/Ghost/releases/tag/v6.45.0`,
-    de_DE: `Aktualisiert Ghost auf 6.45.0.
+Notas de la versión completas: https://github.com/TryGhost/Ghost/releases/tag/v6.46.0`,
+    de_DE: `Aktualisiert Ghost auf 6.46.0.
 
-- Fügt IndexNow hinzu, um Suchmaschinen über Inhaltsänderungen zu informieren.
-- Aktualisiert die Themes Source und Casper.
-- Zahlreiche Fehlerbehebungen bei Kommentaren, Mitgliedern, dem Editor und Portal.
+- Behebt das Deaktivieren strukturierter Daten für LLMs und KI-Suchmaschinen.
+- Behebt das stille Verwerfen von Inhalten beim Import durch Anzeige von Validierungsfehlern.
+- Zahlreiche Fehlerbehebungen bei Mitgliedern, Newslettern, dem Checkout und dem Editor.
 
-Vollständige Versionshinweise: https://github.com/TryGhost/Ghost/releases/tag/v6.45.0`,
-    pl_PL: `Aktualizuje Ghost do 6.45.0.
+Vollständige Versionshinweise: https://github.com/TryGhost/Ghost/releases/tag/v6.46.0`,
+    pl_PL: `Aktualizuje Ghost do 6.46.0.
 
-- Dodaje IndexNow, aby powiadamiać wyszukiwarki o zmianach treści.
-- Aktualizuje motywy Source i Casper.
-- Liczne poprawki błędów w komentarzach, członkach, edytorze i Portalu.
+- Naprawia wyłączanie danych strukturalnych dla LLM i wyszukiwarek AI.
+- Naprawia ciche pomijanie treści przez importer, pokazując błędy walidacji.
+- Liczne poprawki w członkach, newsletterach, płatnościach i edytorze.
 
-Pełne informacje o wydaniu: https://github.com/TryGhost/Ghost/releases/tag/v6.45.0`,
-    fr_FR: `Met à jour Ghost vers 6.45.0.
+Pełne informacje o wydaniu: https://github.com/TryGhost/Ghost/releases/tag/v6.46.0`,
+    fr_FR: `Met à jour Ghost vers 6.46.0.
 
-- Ajoute IndexNow pour informer les moteurs de recherche des changements de contenu.
-- Met à jour les thèmes Source et Casper.
-- Nombreuses corrections de bugs dans les commentaires, les membres, l'éditeur et Portal.
+- Corrige la désactivation des données structurées pour les LLM et les moteurs de recherche IA.
+- Corrige l'importateur qui supprimait silencieusement du contenu en affichant les erreurs de validation.
+- Nombreuses corrections dans les membres, les newsletters, le paiement et l'éditeur.
 
-Notes de version complètes : https://github.com/TryGhost/Ghost/releases/tag/v6.45.0`,
+Notes de version complètes : https://github.com/TryGhost/Ghost/releases/tag/v6.46.0`,
   },
   migrations: {
     up: async ({ effects }) => {},

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,13 +1,43 @@
 import { VersionInfo, IMPOSSIBLE } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '6.44.1:0',
+  version: '6.45.0:0',
   releaseNotes: {
-    en_US: 'Bumps Ghost → 6.44.1.',
-    es_ES: 'Actualiza Ghost → 6.44.1.',
-    de_DE: 'Aktualisiert Ghost → 6.44.1.',
-    pl_PL: 'Aktualizuje Ghost → 6.44.1.',
-    fr_FR: 'Met à jour Ghost → 6.44.1.',
+    en_US: `Updated Ghost to 6.45.0.
+
+- Added IndexNow to notify search engines of content changes.
+- Updated the Source and Casper themes.
+- Numerous bug fixes across comments, members, the editor, and Portal.
+
+Full release notes: https://github.com/TryGhost/Ghost/releases/tag/v6.45.0`,
+    es_ES: `Actualiza Ghost a 6.45.0.
+
+- Añade IndexNow para notificar a los motores de búsqueda los cambios de contenido.
+- Actualiza los temas Source y Casper.
+- Numerosas correcciones en comentarios, miembros, el editor y Portal.
+
+Notas de la versión completas: https://github.com/TryGhost/Ghost/releases/tag/v6.45.0`,
+    de_DE: `Aktualisiert Ghost auf 6.45.0.
+
+- Fügt IndexNow hinzu, um Suchmaschinen über Inhaltsänderungen zu informieren.
+- Aktualisiert die Themes Source und Casper.
+- Zahlreiche Fehlerbehebungen bei Kommentaren, Mitgliedern, dem Editor und Portal.
+
+Vollständige Versionshinweise: https://github.com/TryGhost/Ghost/releases/tag/v6.45.0`,
+    pl_PL: `Aktualizuje Ghost do 6.45.0.
+
+- Dodaje IndexNow, aby powiadamiać wyszukiwarki o zmianach treści.
+- Aktualizuje motywy Source i Casper.
+- Liczne poprawki błędów w komentarzach, członkach, edytorze i Portalu.
+
+Pełne informacje o wydaniu: https://github.com/TryGhost/Ghost/releases/tag/v6.45.0`,
+    fr_FR: `Met à jour Ghost vers 6.45.0.
+
+- Ajoute IndexNow pour informer les moteurs de recherche des changements de contenu.
+- Met à jour les thèmes Source et Casper.
+- Nombreuses corrections de bugs dans les commentaires, les membres, l'éditeur et Portal.
+
+Notes de version complètes : https://github.com/TryGhost/Ghost/releases/tag/v6.45.0`,
   },
   migrations: {
     up: async ({ effects }) => {},


### PR DESCRIPTION
## Summary

Bumps the wrapped Ghost image from `6.44.1-alpine` to `6.45.0-alpine` and sets the StartOS version to `6.45.0:0`.

- MySQL pin unchanged (`8.4.9`).
- `@start9labs/start-sdk` already at the latest published `1.5.3` — no SDK bump needed.
- `npm update` ran (lockfile refreshed).
- No package-surface changes (volumes/ports/interfaces/actions unchanged), so README/instructions need no updates.

## Upstream highlights (6.45.0)

- ✨ Added IndexNow to notify search engines of content changes.
- 🎨 Updated the Source (v1.7.1) and Casper (v5.12.1) themes.
- 🐛 Numerous bug fixes across comments, members, the editor, and Portal.

Full upstream release notes: https://github.com/TryGhost/Ghost/releases/tag/v6.45.0

## Test plan

- `npm run check` (tsc) passes on `6.45.0:0`.