### PR TITLE
chore: bump Ghost to 6.50.0; 6.49.0:0 → 6.50.0:0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -128,9 +128,9 @@
       }
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
-      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.1.tgz",
+      "integrity": "sha512-tPb5TTWfgfVx5BNSi2xV0eLr89POeXXn0dXIsCJ9m1narrWxeIyx6je9d7Rce/3NyXLbvuQmLkxq+RuxMWejvw==",
       "funding": [
         {
           "type": "github",

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -14,7 +14,7 @@ export const manifest = setupManifest({
   images: {
     ghost: {
       source: {
-        dockerTag: 'ghost:6.49.0-alpine',
+        dockerTag: 'ghost:6.50.0-alpine',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,48 +1,53 @@
 import { VersionInfo, IMPOSSIBLE } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '6.49.0:0',
+  version: '6.50.0:0',
   releaseNotes: {
-    en_US: `Updated Ghost to 6.49.0.
+    en_US: `Updated Ghost to 6.50.0.
 
-- Added markdown and llms.txt support for AI tooling.
-- Recovered newsletter sends interrupted by container restarts.
-- Fixed theme uploads freezing when folders are read-only.
-- Fixed the analytics Today view showing data points in the future.
+- Added publisher gift links.
+- Added a configurable admin session max age.
+- Added a system appearance (light/dark) mode to Ghost Admin.
+- Fixed a stored XSS vulnerability in JSON-LD structured data output.
+- Improved analytics and dark mode across the admin.
 
-Full release notes: https://github.com/TryGhost/Ghost/releases/tag/v6.49.0`,
-    es_ES: `Actualiza Ghost a 6.49.0.
+Full release notes: https://github.com/TryGhost/Ghost/releases/tag/v6.50.0`,
+    es_ES: `Actualiza Ghost a 6.50.0.
 
-- Añade compatibilidad con markdown y llms.txt para herramientas de IA.
-- Recupera los envíos de boletines interrumpidos por reinicios del contenedor.
-- Corrige el bloqueo de las subidas de temas cuando las carpetas son de solo lectura.
-- Corrige que la vista de Hoy de analíticas mostrara puntos de datos en el futuro.
+- Añade enlaces de regalo para editores.
+- Añade una antigüedad máxima configurable para la sesión de administración.
+- Añade un modo de apariencia del sistema (claro/oscuro) a la administración de Ghost.
+- Corrige una vulnerabilidad de XSS almacenado en la salida de datos estructurados JSON-LD.
+- Mejora las analíticas y el modo oscuro en toda la administración.
 
-Notas de la versión completas: https://github.com/TryGhost/Ghost/releases/tag/v6.49.0`,
-    de_DE: `Aktualisiert Ghost auf 6.49.0.
+Notas de la versión completas: https://github.com/TryGhost/Ghost/releases/tag/v6.50.0`,
+    de_DE: `Aktualisiert Ghost auf 6.50.0.
 
-- Fügt Unterstützung für Markdown und llms.txt für KI-Tools hinzu.
-- Stellt durch Container-Neustarts unterbrochene Newsletter-Versände wieder her.
-- Behebt das Einfrieren von Theme-Uploads bei schreibgeschützten Ordnern.
-- Behebt, dass die Heute-Ansicht der Analysen Datenpunkte in der Zukunft anzeigte.
+- Fügt Geschenk-Links für Publisher hinzu.
+- Fügt ein konfigurierbares Höchstalter für Admin-Sitzungen hinzu.
+- Fügt einen Systemdarstellungsmodus (hell/dunkel) zum Ghost-Admin hinzu.
+- Behebt eine Stored-XSS-Schwachstelle in der Ausgabe strukturierter JSON-LD-Daten.
+- Verbessert Analysen und den Dunkelmodus im gesamten Admin.
 
-Vollständige Versionshinweise: https://github.com/TryGhost/Ghost/releases/tag/v6.49.0`,
-    pl_PL: `Aktualizuje Ghost do 6.49.0.
+Vollständige Versionshinweise: https://github.com/TryGhost/Ghost/releases/tag/v6.50.0`,
+    pl_PL: `Aktualizuje Ghost do 6.50.0.
 
-- Dodaje obsługę markdown i llms.txt dla narzędzi AI.
-- Przywraca wysyłki newsletterów przerwane przez restarty kontenera.
-- Naprawia zawieszanie się przesyłania motywów, gdy foldery są tylko do odczytu.
-- Naprawia wyświetlanie przez widok Dziś w analityce punktów danych w przyszłości.
+- Dodaje linki prezentowe dla wydawców.
+- Dodaje konfigurowalny maksymalny czas trwania sesji administratora.
+- Dodaje tryb wyglądu systemu (jasny/ciemny) do panelu administracyjnego Ghost.
+- Naprawia lukę stored XSS w danych strukturalnych JSON-LD.
+- Ulepsza analitykę i tryb ciemny w całym panelu administracyjnym.
 
-Pełne informacje o wydaniu: https://github.com/TryGhost/Ghost/releases/tag/v6.49.0`,
-    fr_FR: `Met à jour Ghost vers 6.49.0.
+Pełne informacje o wydaniu: https://github.com/TryGhost/Ghost/releases/tag/v6.50.0`,
+    fr_FR: `Met à jour Ghost vers 6.50.0.
 
-- Ajoute la prise en charge de markdown et llms.txt pour les outils d'IA.
-- Récupère les envois de newsletters interrompus par les redémarrages du conteneur.
-- Corrige le blocage des téléversements de thèmes lorsque les dossiers sont en lecture seule.
-- Corrige la vue Aujourd'hui des analyses affichant des points de données dans le futur.
+- Ajoute des liens cadeaux pour les éditeurs.
+- Ajoute une durée maximale de session d'administration configurable.
+- Ajoute un mode d'apparence système (clair/sombre) à l'administration de Ghost.
+- Corrige une vulnérabilité XSS stocké dans la sortie de données structurées JSON-LD.
+- Améliore les analyses et le mode sombre dans toute l'administration.
 
-Notes de version complètes : https://github.com/TryGhost/Ghost/releases/tag/v6.49.0`,
+Notes de version complètes : https://github.com/TryGhost/Ghost/releases/tag/v6.50.0`,
   },
   migrations: {
     up: async ({ effects }) => {},


### PR DESCRIPTION
## Summary

Monitor-cycle upstream bump: **Ghost 6.49.0 → 6.50.0** (`startos/versions/current.ts` → `6.50.0:0`, manifest `dockerTag` → `ghost:6.50.0-alpine`).

MySQL stays pinned at `8.4.9` (per `UPDATING.md`, only bump MySQL when intentionally moving it). `@start9labs/start-sdk` is already at the latest published `1.5.3` — no SDK bump. `npm update` floated one transitive dep (`fast-xml-builder` 1.2.0 → 1.2.1).

## Upstream highlights (6.50.0)

- ✨ Publisher gift links
- ✨ Configurable admin session max age
- ✨ System appearance (light/dark) mode in Ghost Admin
- 🐛 Fixed a **stored XSS** vulnerability + mangled structured data in JSON-LD output
- 🎨 Analytics and dark-mode improvements across the admin

Full notes: https://github.com/TryGhost/Ghost/releases/tag/v6.50.0

Minor bump, no breaking changes for the package; no state migration required (`migrations.up` remains a no-op).

## Test plan

- [x] `npm run check` (tsc --noEmit) — green
- [ ] `make` / s9pk pack — deferred to review per monitor-cycle policy