### PR TITLE
chore: bump Ghost to 6.54.1; 6.53.0:2 → 6.54.1:0

### DIFF
--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -14,7 +14,7 @@ export const manifest = setupManifest({
   images: {
     ghost: {
       source: {
-        dockerTag: 'ghost:6.53.0-alpine',
+        dockerTag: 'ghost:6.54.1-alpine',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,33 +1,48 @@
 import { VersionInfo, IMPOSSIBLE } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '6.53.0:2',
+  version: '6.54.1:0',
   releaseNotes: {
-    en_US: `Updated Ghost to 6.53.0.
+    en_US: `Updated Ghost to 6.54.1.
 
-This release also migrates the package to start-sdk 2.0 (requires StartOS 0.4.0-beta.10 or later).
+- Hardened upload filename generation.
+- Added an inline editor for routes.yaml and redirects.yaml in the admin panel.
+- Added member labels, complimentary subscriptions, and member gravatars in themes.
+- Fixed several members CSV import bugs, sitemap handling of self-referential canonical URLs, and a settings preview regression.
 
-Full release notes: https://github.com/TryGhost/Ghost/releases/tag/v6.53.0`,
-    es_ES: `Actualiza Ghost a 6.53.0.
+Full release notes: https://github.com/TryGhost/Ghost/releases/tag/v6.54.1`,
+    es_ES: `Actualiza Ghost a 6.54.1.
 
-Esta versión también migra el paquete a start-sdk 2.0 (requiere StartOS 0.4.0-beta.10 o posterior).
+- Refuerza la generación de nombres de los archivos subidos.
+- Añade un editor integrado para routes.yaml y redirects.yaml en el panel de administración.
+- Añade etiquetas de miembros, suscripciones de cortesía y gravatares de miembros en los temas.
+- Corrige varios errores de importación CSV de miembros, el tratamiento de URLs canónicas autorreferenciales en el mapa del sitio y una regresión en la vista previa de ajustes.
 
-Notas de la versión completas: https://github.com/TryGhost/Ghost/releases/tag/v6.53.0`,
-    de_DE: `Aktualisiert Ghost auf 6.53.0.
+Notas de la versión completas: https://github.com/TryGhost/Ghost/releases/tag/v6.54.1`,
+    de_DE: `Aktualisiert Ghost auf 6.54.1.
 
-Diese Version stellt das Paket außerdem auf start-sdk 2.0 um (erfordert StartOS 0.4.0-beta.10 oder neuer).
+- Härtet die Erzeugung von Dateinamen beim Hochladen.
+- Fügt einen integrierten Editor für routes.yaml und redirects.yaml im Admin-Bereich hinzu.
+- Fügt Mitglieder-Labels, Gratis-Abonnements und Mitglieder-Gravatare in Themes hinzu.
+- Behebt mehrere Fehler beim CSV-Import von Mitgliedern, die Behandlung selbstreferenzieller kanonischer URLs in der Sitemap sowie eine Regression in der Einstellungsvorschau.
 
-Vollständige Versionshinweise: https://github.com/TryGhost/Ghost/releases/tag/v6.53.0`,
-    pl_PL: `Aktualizuje Ghost do 6.53.0.
+Vollständige Versionshinweise: https://github.com/TryGhost/Ghost/releases/tag/v6.54.1`,
+    pl_PL: `Aktualizuje Ghost do 6.54.1.
 
-Ta wersja przenosi też pakiet na start-sdk 2.0 (wymaga StartOS 0.4.0-beta.10 lub nowszego).
+- Wzmacnia generowanie nazw przesyłanych plików.
+- Dodaje wbudowany edytor plików routes.yaml i redirects.yaml w panelu administracyjnym.
+- Dodaje etykiety członków, subskrypcje gratisowe oraz gravatary członków w motywach.
+- Naprawia kilka błędów importu CSV członków, obsługę samoodwołujących się adresów kanonicznych w mapie witryny oraz regresję w podglądzie ustawień.
 
-Pełne informacje o wydaniu: https://github.com/TryGhost/Ghost/releases/tag/v6.53.0`,
-    fr_FR: `Met à jour Ghost vers 6.53.0.
+Pełne informacje o wydaniu: https://github.com/TryGhost/Ghost/releases/tag/v6.54.1`,
+    fr_FR: `Met à jour Ghost vers 6.54.1.
 
-Cette version fait également passer le paquet à start-sdk 2.0 (nécessite StartOS 0.4.0-beta.10 ou une version ultérieure).
+- Renforce la génération des noms de fichiers téléversés.
+- Ajoute un éditeur intégré pour routes.yaml et redirects.yaml dans le panneau d'administration.
+- Ajoute les étiquettes de membres, les abonnements offerts et les gravatars de membres dans les thèmes.
+- Corrige plusieurs bogues d'import CSV des membres, la gestion des URL canoniques auto-référentielles dans le sitemap et une régression de l'aperçu des réglages.
 
-Notes de version complètes : https://github.com/TryGhost/Ghost/releases/tag/v6.53.0`,
+Notes de version complètes : https://github.com/TryGhost/Ghost/releases/tag/v6.54.1`,
   },
   migrations: {
     up: async ({ effects }) => {},


### PR DESCRIPTION
## Summary

Bumps Ghost from **6.53.0** to **6.54.1** (`ghost:6.54.1-alpine`), and the StartOS version from `6.53.0:2` to `6.54.1:0`.

MySQL stays pinned at `mysql:8.4.10` — per `UPDATING.md`, it moves only when we intentionally change the database line, and 8.4 is what this Ghost release targets.

`@start9labs/start-sdk` is already at `2.0.9`, the current npm latest, so no SDK bump rode along. No npm state changed (no git dependencies in this package; `npm ci` reproduces the committed lock).

## Upstream highlights (6.53.0 → 6.54.1)

- 🔒 Filename generation for uploads made more secure, performant, and resilient to filesystem limits.
- ✨ Inline editor for `routes.yaml` and `redirects.yaml` in the admin panel.
- ✨ Member labels, complimentary member subscriptions, and `member.avatar_image` gravatars for themes.
- ✨ Config option for a custom adapter install location; canary (v4) schema/API endpoint.
- 🐛 Several members CSV import fixes (labels containing commas, formula-escape characters, uneven columns), sitemap now includes posts with a self-referential canonical URL, dark-mode loader background, YouTube bookmark metadata.
- 🐛 6.54.1 patch: fixed settings preview interaction regressions introduced in 6.54.0.

Full notes: [v6.54.0](https://github.com/TryGhost/Ghost/releases/tag/v6.54.0) · [v6.54.1](https://github.com/TryGhost/Ghost/releases/tag/v6.54.1)

## Verification

- `ghost:6.54.1-alpine` confirmed published on Docker Hub with both `amd64` and `arm64` manifests (pushed 2026-07-27).
- `6.54.1:0` is free — the registry currently has `6.53.0:2` as latest.
- `npm run check` (tsc) green.
- No migration needed: the release carries no StartOS-side state change, so `current.ts` was edited in place.

## Docs

`README.md` and `instructions.md` carry no version numbers and describe no behavior this release changes, so neither needed an update. The new admin-side `routes.yaml`/`redirects.yaml` editor is entirely within Ghost's own admin panel.
