### PR TITLE
chore: bump Ghost to 6.56.0; 6.55.0:0 → 6.56.0:0

### DIFF
--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -14,7 +14,7 @@ export const manifest = setupManifest({
   images: {
     ghost: {
       source: {
-        dockerTag: 'ghost:6.55.0-alpine',
+        dockerTag: 'ghost:6.56.0-alpine',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,58 +1,58 @@
 import { VersionInfo, IMPOSSIBLE } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '6.55.0:0',
+  version: '6.56.0:0',
   releaseNotes: {
-    en_US: `Updated Ghost to 6.55.0.
+    en_US: `Updated Ghost to 6.56.0.
 
-A bug-fix release:
+A small feature and bug-fix release:
 
-- Fixed members being unsubscribed from every newsletter when unsubscribing from one.
-- Fixed broken admin views for Contributor and Author staff users.
-- Fixed redirect capture groups not being substituted inside query strings.
-- Fixed duplicate reply notification emails, broken internal links in automation emails, and feature image alt text being dropped when too long.
+- Added a specific-tier option to the editor preview.
+- Fixed a 500 error when deleting posts that have threaded comments.
+- Fixed Stripe checkout failing for accounts with Managed Payments enabled.
+- Fixed newsletter links containing a single quote being impossible to edit, SVG favicons not rendering in bookmark cards, and header cards losing their layout when imported from HTML.
 
-Full release notes: https://github.com/TryGhost/Ghost/releases/tag/v6.55.0`,
-    es_ES: `Actualiza Ghost a 6.55.0.
+Full release notes: https://github.com/TryGhost/Ghost/releases/tag/v6.56.0`,
+    es_ES: `Actualiza Ghost a 6.56.0.
 
-Una versión de corrección de errores:
+Una versión con una pequeña función y correcciones de errores:
 
-- Corrige que los miembros se dieran de baja de todos los boletines al darse de baja de uno.
-- Corrige vistas de administración rotas para los usuarios con rol Colaborador y Autor.
-- Corrige que los grupos de captura de las redirecciones no se sustituyeran dentro de las cadenas de consulta.
-- Corrige correos de notificación de respuesta duplicados, enlaces internos rotos en los correos de automatización y la pérdida del texto alternativo de la imagen destacada cuando era demasiado largo.
+- Añade una opción de nivel específico en la vista previa del editor.
+- Corrige un error 500 al eliminar publicaciones con comentarios en hilo.
+- Corrige el fallo del pago de Stripe en cuentas con Pagos Gestionados activados.
+- Corrige que los enlaces de boletines con comillas simples no se pudieran editar, que los favicons SVG no se mostraran en las tarjetas de marcador y que las tarjetas de encabezado perdieran su diseño al importarse desde HTML.
 
-Notas de la versión completas: https://github.com/TryGhost/Ghost/releases/tag/v6.55.0`,
-    de_DE: `Aktualisiert Ghost auf 6.55.0.
+Notas de la versión completas: https://github.com/TryGhost/Ghost/releases/tag/v6.56.0`,
+    de_DE: `Aktualisiert Ghost auf 6.56.0.
 
-Eine Fehlerbehebungs-Version:
+Eine Version mit einer kleinen Funktion und Fehlerbehebungen:
 
-- Behebt, dass Mitglieder beim Abmelden von einem Newsletter von allen Newslettern abgemeldet wurden.
-- Behebt fehlerhafte Admin-Ansichten für Benutzer mit den Rollen Mitwirkender und Autor.
-- Behebt, dass Erfassungsgruppen in Weiterleitungen innerhalb von Query-Strings nicht ersetzt wurden.
-- Behebt doppelte Antwort-Benachrichtigungs-E-Mails, fehlerhafte interne Links in Automatisierungs-E-Mails und den Verlust zu langer Alternativtexte von Beitragsbildern.
+- Fügt in der Editor-Vorschau eine Option für eine bestimmte Stufe hinzu.
+- Behebt einen 500-Fehler beim Löschen von Beiträgen mit verschachtelten Kommentaren.
+- Behebt fehlschlagende Stripe-Zahlungen bei Konten mit aktivierten verwalteten Zahlungen.
+- Behebt, dass Newsletter-Links mit einem Apostroph nicht bearbeitet werden konnten, SVG-Favicons in Lesezeichen-Karten nicht dargestellt wurden und Header-Karten beim Import aus HTML ihr Layout verloren.
 
-Vollständige Versionshinweise: https://github.com/TryGhost/Ghost/releases/tag/v6.55.0`,
-    pl_PL: `Aktualizuje Ghost do 6.55.0.
+Vollständige Versionshinweise: https://github.com/TryGhost/Ghost/releases/tag/v6.56.0`,
+    pl_PL: `Aktualizuje Ghost do 6.56.0.
 
-Wydanie naprawiające błędy:
+Wydanie z drobną nowością i poprawkami błędów:
 
-- Naprawia wypisywanie członków ze wszystkich newsletterów przy rezygnacji z jednego.
-- Naprawia niedziałające widoki panelu administracyjnego dla ról Współpracownik i Autor.
-- Naprawia brak podstawiania grup przechwytywania przekierowań wewnątrz parametrów zapytania.
-- Naprawia duplikaty powiadomień e-mail o odpowiedziach, niedziałające linki wewnętrzne w e-mailach automatyzacji oraz utratę zbyt długiego tekstu alternatywnego obrazu wyróżniającego.
+- Dodaje opcję wyboru konkretnego poziomu w podglądzie edytora.
+- Naprawia błąd 500 przy usuwaniu wpisów z komentarzami w wątkach.
+- Naprawia nieudane płatności Stripe na kontach z włączonymi płatnościami zarządzanymi.
+- Naprawia brak możliwości edycji linków newslettera zawierających apostrof, niewyświetlanie favicon w formacie SVG na kartach zakładek oraz utratę układu kart nagłówkowych przy imporcie z HTML.
 
-Pełne informacje o wydaniu: https://github.com/TryGhost/Ghost/releases/tag/v6.55.0`,
-    fr_FR: `Met à jour Ghost vers 6.55.0.
+Pełne informacje o wydaniu: https://github.com/TryGhost/Ghost/releases/tag/v6.56.0`,
+    fr_FR: `Met à jour Ghost vers 6.56.0.
 
-Une version de correction de bogues :
+Une version apportant une petite fonctionnalité et des corrections de bogues :
 
-- Corrige le désabonnement des membres de toutes les newsletters lors du désabonnement d'une seule.
-- Corrige les vues d'administration cassées pour les utilisateurs Contributeur et Auteur.
-- Corrige la non-substitution des groupes de capture des redirections dans les chaînes de requête.
-- Corrige les e-mails de notification de réponse en double, les liens internes cassés dans les e-mails d'automatisation et la perte du texte alternatif trop long de l'image à la une.
+- Ajoute une option de palier spécifique dans l'aperçu de l'éditeur.
+- Corrige une erreur 500 lors de la suppression d'articles comportant des commentaires en fil de discussion.
+- Corrige l'échec du paiement Stripe pour les comptes avec les paiements gérés activés.
+- Corrige les liens de newsletter contenant une apostrophe impossibles à modifier, les favicons SVG non affichés dans les cartes de signet et les cartes d'en-tête perdant leur mise en page à l'import depuis HTML.
 
-Notes de version complètes : https://github.com/TryGhost/Ghost/releases/tag/v6.55.0`,
+Notes de version complètes : https://github.com/TryGhost/Ghost/releases/tag/v6.56.0`,
   },
   migrations: {
     up: async ({ effects }) => {},


### PR DESCRIPTION
Bumps the Ghost image to `ghost:6.56.0-alpine` and releases `6.56.0:0`.

## Upstream

[Ghost 6.56.0](https://github.com/TryGhost/Ghost/releases/tag/v6.56.0) — a small feature and bug-fix release:

- Specific-tier option in the editor preview, plus configurable billing search entries.
- Fixes a 500 error when deleting posts with threaded comments.
- Fixes Stripe checkout failing for accounts with Managed Payments enabled.
- Fixes uneditable newsletter links containing a single quote, SVG favicons not rendering in bookmark cards, header cards losing their layout on HTML import, and keyboard focus trapping in empty comment threads.

Nothing breaking for the package: no config, volume, interface or action changes, so no migration is needed. `README.md` and `instructions.md` carry no version numbers and describe nothing this release touches.

## Verification

- `ghost:6.56.0-alpine` resolves on Docker Hub for both `amd64` and `arm64`.
- `@start9labs/start-sdk` is already at the latest published version (2.0.9) — no SDK bump, no lockfile change. No `*-startos` git dependencies to refresh.
- MySQL is left at `8.4.10` per `UPDATING.md` (bump only when intentionally moving it); `8.4.11` is available if you'd like it to ride along.
- Registry latest is `6.55.0:0`, so `6.56.0:0` is free.

## Test plan

- [x] `npm run check` green.
- [ ] `make` builds a `6.56.0:0` s9pk.
- [ ] Install/upgrade, Ghost and MySQL start, `primary` and `admin` interfaces reachable.