### PR TITLE
chore: bump Ghost to 6.57.1; 6.56.0:0 → 6.57.1:0

### DIFF
--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -14,7 +14,7 @@ export const manifest = setupManifest({
   images: {
     ghost: {
       source: {
-        dockerTag: 'ghost:6.56.0-alpine',
+        dockerTag: 'ghost:6.57.1-alpine',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,58 +1,68 @@
 import { VersionInfo, IMPOSSIBLE } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '6.56.0:0',
+  version: '6.57.1:0',
   releaseNotes: {
-    en_US: `Updated Ghost to 6.56.0.
+    en_US: `Updated Ghost to 6.57.1, covering the 6.57.0 and 6.57.1 releases.
 
-A small feature and bug-fix release:
+One new feature and a batch of bug fixes:
 
-- Added a specific-tier option to the editor preview.
-- Fixed a 500 error when deleting posts that have threaded comments.
-- Fixed Stripe checkout failing for accounts with Managed Payments enabled.
-- Fixed newsletter links containing a single quote being impossible to edit, SVG favicons not rendering in bookmark cards, and header cards losing their layout when imported from HTML.
+- Added analytics for email sequences.
+- Fixed web analytics failing to load while the admin panel was still booting.
+- Fixed the admin toolbar causing redirect loops on sites served from a subdirectory.
+- Fixed theme settings being reset when editing the Source or Casper themes.
+- Fixed the member.edited webhook not firing when a paid plan is cancelled or reinstated, and missing tiers in that webhook's previous-state payload.
+- Fixed contrast_text_color returning the wrong text color for some light backgrounds, and missing spaces when using multiple attributes in the link helper.
 
-Full release notes: https://github.com/TryGhost/Ghost/releases/tag/v6.56.0`,
-    es_ES: `Actualiza Ghost a 6.56.0.
+Full release notes: https://github.com/TryGhost/Ghost/compare/v6.56.0...v6.57.1`,
+    es_ES: `Actualiza Ghost a 6.57.1, incluyendo las versiones 6.57.0 y 6.57.1.
 
-Una versión con una pequeña función y correcciones de errores:
+Una función nueva y un conjunto de correcciones:
 
-- Añade una opción de nivel específico en la vista previa del editor.
-- Corrige un error 500 al eliminar publicaciones con comentarios en hilo.
-- Corrige el fallo del pago de Stripe en cuentas con Pagos Gestionados activados.
-- Corrige que los enlaces de boletines con comillas simples no se pudieran editar, que los favicons SVG no se mostraran en las tarjetas de marcador y que las tarjetas de encabezado perdieran su diseño al importarse desde HTML.
+- Añade analíticas para las secuencias de correo.
+- Corrige que las analíticas web no se cargaran mientras el panel de administración aún se estaba iniciando.
+- Corrige que la barra de herramientas de administración provocara bucles de redirección en sitios servidos desde un subdirectorio.
+- Corrige que la configuración del tema se restableciera al editar los temas Source o Casper.
+- Corrige que el webhook member.edited no se activara al cancelar o reactivar un plan de pago, y la ausencia de niveles en el estado anterior de dicho webhook.
+- Corrige que contrast_text_color devolviera un color de texto incorrecto con algunos fondos claros y la falta de espacios al usar varios atributos en el helper de enlaces.
 
-Notas de la versión completas: https://github.com/TryGhost/Ghost/releases/tag/v6.56.0`,
-    de_DE: `Aktualisiert Ghost auf 6.56.0.
+Notas de la versión completas: https://github.com/TryGhost/Ghost/compare/v6.56.0...v6.57.1`,
+    de_DE: `Aktualisiert Ghost auf 6.57.1 und umfasst die Versionen 6.57.0 und 6.57.1.
 
-Eine Version mit einer kleinen Funktion und Fehlerbehebungen:
+Eine neue Funktion und eine Reihe von Fehlerbehebungen:
 
-- Fügt in der Editor-Vorschau eine Option für eine bestimmte Stufe hinzu.
-- Behebt einen 500-Fehler beim Löschen von Beiträgen mit verschachtelten Kommentaren.
-- Behebt fehlschlagende Stripe-Zahlungen bei Konten mit aktivierten verwalteten Zahlungen.
-- Behebt, dass Newsletter-Links mit einem Apostroph nicht bearbeitet werden konnten, SVG-Favicons in Lesezeichen-Karten nicht dargestellt wurden und Header-Karten beim Import aus HTML ihr Layout verloren.
+- Fügt Analysen für E-Mail-Sequenzen hinzu.
+- Behebt, dass die Web-Analysen nicht geladen wurden, während der Admin-Bereich noch startete.
+- Behebt Weiterleitungsschleifen der Admin-Symbolleiste auf Seiten in einem Unterverzeichnis.
+- Behebt das Zurücksetzen der Theme-Einstellungen beim Bearbeiten der Themes Source und Casper.
+- Behebt, dass der Webhook member.edited beim Kündigen oder Reaktivieren eines kostenpflichtigen Plans nicht ausgelöst wurde, sowie fehlende Stufen im vorherigen Zustand dieses Webhooks.
+- Behebt, dass contrast_text_color bei manchen hellen Hintergründen eine falsche Textfarbe zurückgab, und fehlende Leerzeichen bei mehreren Attributen im Link-Helper.
 
-Vollständige Versionshinweise: https://github.com/TryGhost/Ghost/releases/tag/v6.56.0`,
-    pl_PL: `Aktualizuje Ghost do 6.56.0.
+Vollständige Versionshinweise: https://github.com/TryGhost/Ghost/compare/v6.56.0...v6.57.1`,
+    pl_PL: `Aktualizuje Ghost do 6.57.1, obejmując wydania 6.57.0 i 6.57.1.
 
-Wydanie z drobną nowością i poprawkami błędów:
+Jedna nowa funkcja i zestaw poprawek błędów:
 
-- Dodaje opcję wyboru konkretnego poziomu w podglądzie edytora.
-- Naprawia błąd 500 przy usuwaniu wpisów z komentarzami w wątkach.
-- Naprawia nieudane płatności Stripe na kontach z włączonymi płatnościami zarządzanymi.
-- Naprawia brak możliwości edycji linków newslettera zawierających apostrof, niewyświetlanie favicon w formacie SVG na kartach zakładek oraz utratę układu kart nagłówkowych przy imporcie z HTML.
+- Dodaje statystyki dla sekwencji e-mail.
+- Naprawia brak wczytywania statystyk internetowych, gdy panel administracyjny jeszcze się uruchamiał.
+- Naprawia pętle przekierowań paska narzędzi administratora na stronach serwowanych z podkatalogu.
+- Naprawia resetowanie ustawień motywu podczas edycji motywów Source i Casper.
+- Naprawia brak wywołania webhooka member.edited przy anulowaniu lub przywróceniu planu płatnego oraz brakujące poziomy w poprzednim stanie tego webhooka.
+- Naprawia zwracanie przez contrast_text_color błędnego koloru tekstu dla niektórych jasnych teł oraz brakujące spacje przy użyciu wielu atrybutów w helperze linków.
 
-Pełne informacje o wydaniu: https://github.com/TryGhost/Ghost/releases/tag/v6.56.0`,
-    fr_FR: `Met à jour Ghost vers 6.56.0.
+Pełne informacje o wydaniu: https://github.com/TryGhost/Ghost/compare/v6.56.0...v6.57.1`,
+    fr_FR: `Met à jour Ghost vers 6.57.1, couvrant les versions 6.57.0 et 6.57.1.
 
-Une version apportant une petite fonctionnalité et des corrections de bogues :
+Une nouvelle fonctionnalité et une série de corrections :
 
-- Ajoute une option de palier spécifique dans l'aperçu de l'éditeur.
-- Corrige une erreur 500 lors de la suppression d'articles comportant des commentaires en fil de discussion.
-- Corrige l'échec du paiement Stripe pour les comptes avec les paiements gérés activés.
-- Corrige les liens de newsletter contenant une apostrophe impossibles à modifier, les favicons SVG non affichés dans les cartes de signet et les cartes d'en-tête perdant leur mise en page à l'import depuis HTML.
+- Ajoute des statistiques pour les séquences d'e-mails.
+- Corrige le non-chargement des statistiques web pendant le démarrage du panneau d'administration.
+- Corrige les boucles de redirection de la barre d'outils d'administration sur les sites servis depuis un sous-répertoire.
+- Corrige la réinitialisation des réglages du thème lors de la modification des thèmes Source ou Casper.
+- Corrige le webhook member.edited qui ne se déclenchait pas lors de l'annulation ou du rétablissement d'un abonnement payant, ainsi que les paliers manquants dans l'état précédent de ce webhook.
+- Corrige contrast_text_color renvoyant une couleur de texte incorrecte sur certains fonds clairs et les espaces manquants avec plusieurs attributs dans le helper de lien.
 
-Notes de version complètes : https://github.com/TryGhost/Ghost/releases/tag/v6.56.0`,
+Notes de version complètes : https://github.com/TryGhost/Ghost/compare/v6.56.0...v6.57.1`,
   },
   migrations: {
     up: async ({ effects }) => {},


### PR DESCRIPTION
Bumps Ghost from 6.56.0 to 6.57.1, spanning the upstream 6.57.0 and 6.57.1 releases.

## Changes

- `startos/manifest/index.ts`: `ghost:6.56.0-alpine` → `ghost:6.57.1-alpine`. Tag verified on Docker Hub (published 2026-08-11) with both `linux/amd64` and `linux/arm64` manifests.
- `startos/versions/current.ts`: `6.56.0:0` → `6.57.1:0`, with release notes in all five locales.

MySQL stays at `mysql:8.4.10` — per `UPDATING.md`, it moves only when we intentionally move it. start-sdk is already on the latest published version (2.0.9), and this package has no `*-startos` git dependencies, so no lockfile churn.

## Upstream highlights

**6.57.0**
- Added analytics for email sequences.
- Fixed web analytics failing to load while the admin panel was still booting.
- Fixed missing spaces when using multiple attributes in the link helper.

**6.57.1**
- Fixed admin toolbar redirect loops on subdirectory sites.
- Fixed theme settings being reset when editing the Source or Casper themes.
- Fixed the `member.edited` webhook not firing on cancellation/reinstatement of paid plans, and missing tiers in its previous-state payload.
- Fixed `contrast_text_color` returning the wrong text color for some light backgrounds.

Full changelog: https://github.com/TryGhost/Ghost/compare/v6.56.0...v6.57.1

No breaking changes, no migration needed. `README.md` and `instructions.md` describe no version-specific or structural behavior touched by this bump, so both are unchanged.

## Test plan

- `npm run check` — green.
- Registry check: latest published is `6.56.0:0`, so `6.57.1:0` is free.
- Full `make` / s9pk verification happens in review.
